### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -1,4 +1,6 @@
 name: Quick Check
+permissions:
+  contents: read
 
 # This workflow runs on every push for fast feedback
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/1](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block with minimum required access. Since the workflow uses only actions that read repository contents, does not write to issues or pull requests, and does not interact with other resources, the safest default is `permissions: contents: read`. This can be added either at the root of the workflow, applying to all jobs (preferred), or specifically to the `quick-test` job. Edit `.github/workflows/quick-check.yml` by inserting a `permissions:` block after the workflow’s `name:`—before `on:`. No other changes, imports, nor additional configuration are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
