### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/3](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/3)

The best way to fix the problem is to add an explicit `permissions` block to the workflow. Because none of the jobs require write permissions to repository contents, it is recommended to set the permissions at the workflow root level so that all jobs inherit it. The minimal required permission for most CI tasks is `contents: read`. If, in the future, a job does require more (such as to write PR comments), it should have a job-level override. 

The required change is to insert a block at the top of the workflow file, directly under the `name:` and before the `on:` key, as shown in the example. This only requires editing `.github/workflows/ci.yml`, and no other code or imports need to change. No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
