### PR TITLE
Potential fix for code scanning alert no. 33: Incomplete URL substring sanitization

### DIFF
--- a/devdocai/quality/dimensions.py
+++ b/devdocai/quality/dimensions.py
@@ -9,7 +9,7 @@ import logging
 from typing import Dict, List, Tuple, Optional, Set
 from collections import Counter
 from datetime import datetime, timedelta
-
+from urllib.parse import urlparse
 from .models import QualityDimension, QualityIssue, SeverityLevel, DimensionScore
 from .scoring import ScoringMetrics
 from .exceptions import DimensionAnalysisError
@@ -612,7 +612,7 @@ class AccuracyAnalyzer(DimensionAnalyzer):
             # Simple heuristic checks
             if url.startswith('http://localhost') or url.startswith('http://127.0.0.1'):
                 broken.append(url)
-            elif 'example.com' in url:
+            elif urlparse(url).hostname == "example.com":
                 broken.append(url)
             elif url.endswith('.broken') or url.endswith('.invalid'):
                 broken.append(url)

--- a/devdocai/quality/dimensions.py
+++ b/devdocai/quality/dimensions.py
@@ -612,7 +612,7 @@ class AccuracyAnalyzer(DimensionAnalyzer):
             # Simple heuristic checks
             if url.startswith('http://localhost') or url.startswith('http://127.0.0.1'):
                 broken.append(url)
-            elif urlparse(url).hostname == "example.com":
+            elif urlparse(url).hostname and urlparse(url).hostname == "example.com":
                 broken.append(url)
             elif url.endswith('.broken') or url.endswith('.invalid'):
                 broken.append(url)


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/33](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/33)

To fix this problem, the code should avoid using substring checks against the URL and instead parse the URL to inspect its host component. The `urllib.parse` module provides a means to extract the hostname from a URL. To check if a link points to `example.com`, examine the parsed host and verify strictly (with `== 'example.com'`) or allow subdomains as necessary (with `.endswith('.example.com')`). Only URLs to the exact host (or desired subdomain scope) should be considered as broken (or placeholder/invalid) links.

Specifically, in `AccuracyAnalyzer._find_broken_links`, replace the substring check `'example.com' in url:` with a check using `urlparse(url).hostname` and comparing the hostname directly. Add an import for `urlparse` if not already present.

All changes are strictly local to lines 615-616.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
