### PR TITLE
Potential fix for code scanning alert no. 35: Bad HTML filtering regexp

### DIFF
--- a/devdocai/templates/template_security.py
+++ b/devdocai/templates/template_security.py
@@ -269,7 +269,7 @@ class TemplateSecurity:
             # Fallback to basic sanitization if bleach not available
             cleaned = html
             # Remove script tags
-            cleaned = re.sub(r'<script[^>]*>.*?</script>', '', cleaned, flags=re.DOTALL | re.IGNORECASE)
+            cleaned = re.sub(r'<script[^>]*>.*?</script\b[^>]*>', '', cleaned, flags=re.DOTALL | re.IGNORECASE)
             # Remove event handlers
             cleaned = re.sub(r'\s*on\w+\s*=\s*["\'][^"\']*["\']', '', cleaned, flags=re.IGNORECASE)
             # Escape remaining HTML


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/35](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/35)

To properly address this, we must update the regex to match "forgiving" end tags that browsers treat as valid, such as `</script foo="bar">`. This can be done by modifying the regex so the end tag matches a tag name followed by optional whitespace and any non-'>' characters before the `'>'`. That is, replacing `</script>` with `</script\b[^>]*>`. Thus, the replacement would be:

```python
cleaned = re.sub(r'<script[^>]*>.*?</script\b[^>]*>', '', cleaned, flags=re.DOTALL | re.IGNORECASE)
```

We'll update line 272 accordingly, using this improved pattern for script tags. No additional imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
