### PR TITLE
Potential fix for code scanning alert no. 36: Bad HTML filtering regexp

### DIFF
--- a/devdocai/review/security_validator.py
+++ b/devdocai/review/security_validator.py
@@ -101,7 +101,7 @@ class SecurityValidator:
     ]
     
     XSS_PATTERNS = [
-        re.compile(r'<script[^>]*>.*?</script>', re.IGNORECASE | re.DOTALL),
+        re.compile(r'<script[^>]*>.*?</script[^>]*>', re.IGNORECASE | re.DOTALL),
         re.compile(r'javascript:', re.IGNORECASE),
         re.compile(r'on\w+\s*=', re.IGNORECASE),  # Event handlers
         re.compile(r'<iframe[^>]*>', re.IGNORECASE),


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/36](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/36)

The best fix is to **remove reliance on regular expressions for filtering HTML/script tags** and rely on a robust sanitizer such as `bleach`, which is already imported. If the `XSS_PATTERNS` list is used for filtering content, it should be removed and all such filtering should use `bleach.clean`. If it's used only for detection (and auditing), the script tag matching pattern should be updated to match malformed closing tags: e.g., matching `</script[^>]*>` rather than just `</script>`. 

- If you must retain a regex for detection (not filtering), update the script tag pattern so it matches closing tags with optional attributes and whitespace:  
  Change  
  ```python
  re.compile(r'<script[^>]*>.*?</script>', re.IGNORECASE | re.DOTALL)
  ```
  to  
  ```python
  re.compile(r'<script[^>]*>.*?</script[^>]*>', re.IGNORECASE | re.DOTALL)
  ```
  This makes the closing tag robust against browser laxity.
- If possible, always use `bleach.clean` for actual sanitization of user-supplied HTML content.
- No new import needed, as `bleach` is already available.

Thus, for file `devdocai/review/security_validator.py`, update the regex in `XSS_PATTERNS` on line 104 to use `</script[^>]*>` instead of `</script>`, to catch script blocks even when closing tags are malformed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
