### PR TITLE
Potential fix for code scanning alert no. 37: Bad HTML filtering regexp

### DIFF
--- a/devdocai/llm_adapter/validator.py
+++ b/devdocai/llm_adapter/validator.py
@@ -6,6 +6,7 @@ for all LLM requests to prevent injection attacks and ensure data integrity.
 """
 
 import re
+import bleach
 import json
 import hashlib
 import logging
@@ -503,11 +504,7 @@ class ResponseValidator:
         return any(re.search(p, text, re.IGNORECASE) for p in xss_patterns)
     
     def _sanitize_html(self, text: str) -> str:
-        """Remove potentially dangerous HTML/JavaScript."""
-        # Remove script tags
-        text = re.sub(r'<script[^>]*>.*?</script>', '', text, flags=re.IGNORECASE | re.DOTALL)
-        # Remove event handlers
-        text = re.sub(r'on\w+\s*=\s*["\'][^"\']*["\']', '', text, flags=re.IGNORECASE)
-        # Remove javascript: protocol
-        text = re.sub(r'javascript:', '', text, flags=re.IGNORECASE)
-        return text
+        """Remove potentially dangerous HTML/JavaScript using bleach."""
+        # Remove all HTML tags and attributes to fully sanitize the output.
+        sanitized = bleach.clean(text, tags=[], attributes={}, strip=True)
+        return sanitized


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/37](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/37)

The best way to robustly handle stripping or sanitizing HTML (especially `<script>` tags) is to use a well-tested HTML sanitization library rather than custom regular expressions, as these libraries take browser parsing behaviour into account. In Python, the `bleach` library is a well-known and widely used library for sanitizing HTML and removing unsafe elements. The most robust fix is to replace the regex-based sanitization in the `_sanitize_html` method with a `bleach.clean` call that removes scripts and other dangerous tags and attributes, while preserving safe content.

Specifically, edit the `_sanitize_html` method in `devdocai/llm_adapter/validator.py` as follows:
- Import `bleach` at the top of the file.
- Replace the entire body of `_sanitize_html` so that instead of using regexes to remove scripts, handlers, and JS URLs, it uses `bleach.clean` with `tags=[]` and `attributes={}` to remove all HTML tags by default, or (optionally) configure the allowed tags/attributes appropriately for your use case.
- This ensures all scripts and HTML markup are removed, not just those matching hand-rolled regexes.

No other code needs to be changed, as this is the only region responsible for sanitizing output against XSS vectors.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
