### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,4 +1,6 @@
 name: Dependency and Security Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/40](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/40)

The best way to fix this problem is to add a `permissions` block at the root of the workflow file. This restricts the permissions of the `GITHUB_TOKEN` for all jobs to only what is needed. For most dependency analysis tasks, read-only access to contents is sufficient (`contents: read`). You should add this block near the top level of the workflow, after the `name` and before `jobs:`. If other jobs (like those that create issues or perform repository writes) require more permissions, you can expand the permissions for those jobs specifically, but for now, applying this to the workflow root addresses CodeQL’s finding and enforces least privilege for the default case shown.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
