### PR TITLE
Potential fix for code scanning alert no. 43: Bad HTML filtering regexp

### DIFF
--- a/devdocai/enhancement/security_validator.py
+++ b/devdocai/enhancement/security_validator.py
@@ -634,12 +634,11 @@ class SecurityValidator:
                 'span': ['style'],
                 'p': ['style'],
             })
-            strip = True
             sanitized = bleach.clean(
                 sanitized,
                 tags=allowed_tags,
                 attributes=allowed_attributes,
-                strip=strip,
+                strip=True,
             )
         
         # URL sanitization

--- a/devdocai/enhancement/security_validator.py
+++ b/devdocai/enhancement/security_validator.py
@@ -631,8 +631,8 @@ class SecurityValidator:
             ])
             allowed_attributes = getattr(self.config, 'allowed_html_attributes', {
                 'a': ['href', 'title'],
-                'span': ['style'],
-                'p': ['style'],
+                'span': [],
+                'p': [],
             })
             sanitized = bleach.clean(
                 sanitized,


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/43](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/43)

The best way to fix this problem is to replace the fragile hand-rolled regular expression-based sanitizer with a well-tested, widely-used HTML sanitization library that can robustly handle malformed HTML and dangerous tags/attributes. In Python, the recommended package is `bleach`, which is specifically designed for safe HTML sanitization. You should replace the code from line 626–635, particularly the script/iframe tag regex removals and entity escapes, with a call to `bleach.clean` configured to remove dangerous tags and attributes.

Required changes:
- Add a dependency on `bleach` and import it.
- In `_sanitize_content`, replace the regex-based tag removal and entity escape with `bleach.clean`, specifying allowed tags and attributes, and enabling strict tag stripping.
- Ensure that the sanitizer’s configuration (in `self.config`) for enabling HTML/script sanitization is respected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
