### PR TITLE
Potential fix for code scanning alert no. 44: Bad HTML filtering regexp

### DIFF
--- a/devdocai/security/threat_detector_unified.py
+++ b/devdocai/security/threat_detector_unified.py
@@ -351,7 +351,7 @@ class UnifiedThreatDetector:
             ],
             ThreatType.XSS: [
                 {
-                    'pattern': re.compile(r'<script[^>]*>.*?</script>', re.IGNORECASE | re.DOTALL),
+                    'pattern': re.compile(r'<script\b[^>]*>.*?</script\b[^>]*>', re.IGNORECASE | re.DOTALL),
                     'description': 'Script tag injection',
                     'severity': ThreatLevel.HIGH
                 },


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/44](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/44)

To fix the issue, we must make the threat pattern for script tag injection robust by updating the regex to also match malformed `<script>` closing tags, such as `</script >`, `</script foo="bar">`, and allowing whitespace/newlines.  
- Preferred solution: Use a robust, well-tested HTML parser or sanitizer such as `bleach`, but for threat detection patterns it's reasonable to enhance the regex for wider coverage.
- Update the regex in the `_compile_threat_patterns` function, specifically in the XSS threat patterns, from:
  ```python
  r'<script[^>]*>.*?</script>'
  ```
  to a pattern that matches script blocks and accepts extra attributes or whitespace in the closing tag:
  ```python
  r'<script\b[^>]*>.*?</script\b[^>]*>'
  ```
  This way, the closing tag can tolerate trailing attributes/space (as browsers do):  
    - `<script ...>...</script>`  
    - `<script>...</script foo="bar">`  
    - `<script>...</script >`  
  Also, ensure the regex remains non-greedy with `.*?`.

- No additional imports are needed if we stay with improved regex patterns.

- Only code change required is on line 354 inside the XSS threat pattern block in `_compile_threat_patterns`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
