### PR TITLE
Potential fix for code scanning alert no. 45: Bad HTML filtering regexp

### DIFF
--- a/src/modules/M011-UIComponents/security/security-utils.ts
+++ b/src/modules/M011-UIComponents/security/security-utils.ts
@@ -41,7 +41,7 @@ export const DEFAULT_SECURITY_CONFIG: SecurityConfig = {
  * XSS attack patterns for detection
  */
 const XSS_PATTERNS = [
-  /<script[^>]*>.*?<\/script>/gi,
+  /<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi,
   /javascript:/gi,
   /on\w+\s*=/gi,
   /<iframe[^>]*>/gi,


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/45](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/45)

To properly detect script tags for XSS pattern matching, the regex must recognize `<script ...>` and malformed `</script ...>` tag closers, including cases like `</script foo="bar">` and embedded whitespace. The best solution here is:

1. Replace line 44's pattern with one that matches closing `</script...>` tags containing optional whitespace or extra attributes, e.g.  
   `/\<script\b[^>]*\>[\s\S]*?\<\/script\b[^>]*\>/gi`

2. This allows catching both standard end tags and malformed but browser-accepted ones (e.g. `</script foo="bar">`), as well as interspersed whitespace.

3. No new imports are required since existing code uses regexes for pattern detection; the replacement is a drop-in.

**Region to change:**  
- File: `src/modules/M011-UIComponents/security/security-utils.ts`  
- Line 44 in the `XSS_PATTERNS` array.

No additional definitions or method changes are required; just the regex replacement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
