### PR TITLE
Potential fix for code scanning alert no. 80: Information exposure through an exception

### DIFF
--- a/real_ai_api_server.py
+++ b/real_ai_api_server.py
@@ -670,12 +670,9 @@ def read_file():
         
         except Exception as e:
             logger.error(f"❌ Error reading file {file_path}: {str(e)}")
-            response = jsonify({
-                'success': False,
-                'error': f'Failed to read file: {str(e)}'
-            })
+            response, status = safe_error_response(e, status_code=500)
             response.headers['Access-Control-Allow-Origin'] = 'http://localhost:3000'
-            return response, 500
+            return response, status
     
     except Exception as e:
         logger.error(f"❌ Read file request failed: {str(e)}")


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/80](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/80)

To fix this vulnerability, we should never return raw exception messages to the client. Instead, we should log exception details on the server for audit/debug reasons while responding to the client with a generic error message, such as "Failed to read file." 

Concretely:
- In the inner `except Exception as e:` block inside the `read_file` function, replace the current error response with usage of the existing `safe_error_response` function, which both logs the error and responds with a generic sanitized error message. This function is designed for exactly this purpose.
- The change should be applied directly on the code block beginning at line 671 through 678, replacing construction and return of the `jsonify` response with calling `safe_error_response`.
- If not already present at the top scope, ensure the relevant imports (for `safe_error_response`) are available. In this context, the function is defined above, so no new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
