### PR TITLE
Potential fix for code scanning alert no. 84: Uncontrolled data used in path expression

### DIFF
--- a/real_ai_api_server.py
+++ b/real_ai_api_server.py
@@ -659,7 +659,7 @@ def read_file():
             with open(validated_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             
-            logger.info(f"✅ Successfully read file: {validated_path} ({len(content)} bytes)")
+            logger.info(f"✅ Successfully read file: {file_path} ({len(content)} bytes)")
             
             response = jsonify({
                 'success': True,

--- a/real_ai_api_server.py
+++ b/real_ai_api_server.py
@@ -645,7 +645,9 @@ def read_file():
             if not os.path.isabs(file_path):
                 file_path = os.path.abspath(file_path)
             
-            if not os.path.exists(validate_file_path(file_path)):
+            # Always use the validated path for subsequent operations
+            validated_path = validate_file_path(file_path)
+            if not os.path.exists(validated_path):
                 response = jsonify({
                     'success': False,
                     'error': f'File not found: {file_path}'
@@ -653,11 +655,11 @@ def read_file():
                 response.headers['Access-Control-Allow-Origin'] = 'http://localhost:3000'
                 return response, 404
             
-            # Read the file content
-            with open(file_path, 'r', encoding='utf-8') as f:
+            # Read the file content using the validated path
+            with open(validated_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             
-            logger.info(f"✅ Successfully read file: {file_path} ({len(content)} bytes)")
+            logger.info(f"✅ Successfully read file: {validated_path} ({len(content)} bytes)")
             
             response = jsonify({
                 'success': True,


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/84](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/84)

To fix the uncontrolled data in the path expression, you should ensure that **all file system operations** (both existence checks and reading) operate only on file paths that have been strictly validated/sanitized. The existing `validate_file_path` function is suitable, as it canonicalizes and then checks that a path is contained within a set of allowed directories. Therefore, after verifying that the file exists at the validated path, you should open the file at this validated path, **not** at the originally supplied `file_path`.

The code to change is within the `read_file()` function in real_ai_api_server.py. The fix consists of:
- After validating the path (already done in the existence check), assign the result of `validate_file_path(file_path)` to a variable (e.g., `validated_path`).
- Use `validated_path` for both the existence check and when opening the file for reading.
- Ensure error reporting references the original path received from the user, but the operations themselves are all performed on the validated path.

No additional imports are needed, as all required utilities are already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
