### PR TITLE
Potential fix for code scanning alert no. 92: Information exposure through an exception

### DIFF
--- a/security_fixes.py
+++ b/security_fixes.py
@@ -375,7 +375,8 @@ def secure_generate_endpoint():
         return jsonify(result), 200
         
     except ValueError as e:
-        return jsonify({'error': str(e)}), 400
+        app.logger.warning(f"Input validation failed for user {getattr(g, 'user_id', 'unknown')}: {str(e)}")
+        return jsonify({'error': 'Invalid input.'}), 400
     except Exception as e:
         # Log error securely without exposing details
         app.logger.error(f"Generation failed for user {g.user_id}: {str(e)}")


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/92](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/92)

The fix requires altering the ValueError exception handling at line 378 so that, instead of exposing the error message from the exception directly to the client in `{'error': str(e)}`, a generic error message is returned (e.g., "Invalid input."). The original exception message should still be logged on the server for diagnostic purposes. This prevents potentially sensitive information from being disclosed to clients, following secure coding best practices.

To implement this:
- In the `except ValueError as e:` block, modify the return value to send a generic error message to the client.
- Log the original exception details to the server log using `app.logger` for server-side diagnosis.
- Ensure no stack trace, message, or sensitive details are sent to the client.

If the `app` object is not in the scope of the function, it should be imported or otherwise made available (for logging). Given that `app` is likely defined in the broader context (since `app.logger` is already used in the next exception block), this should be feasible.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
