### PR TITLE
Potential fix for code scanning alert no. 91: Information exposure through an exception

### DIFF
--- a/security_fixes.py
+++ b/security_fixes.py
@@ -89,9 +89,9 @@ class SecurityMiddleware:
                     return jsonify({'error': 'Token expired'}), 401
                     
             except JWTError as e:
-                return jsonify({'error': f'Invalid token: {str(e)}'}), 401
-                
-            return f(*args, **kwargs)
+                # Log the exception on the server, return only a generic message to the client
+                print(f"JWTError caught in require_auth: {str(e)}")  # Consider replacing with logging framework
+                return jsonify({'error': 'Invalid token'}), 401
         return decorated_function
     
     @staticmethod


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/91](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/91)

To fix the problem, we should never expose internal exception messages (such as `str(e)`) directly to the end user. Instead, return a generic error message to the user (such as `"Invalid token"`) and, if necessary, log the exception details for internal/server-side debugging. 

The recommended fix here is:
- Replace the user-facing response in the `except JWTError as e` block on line 92 so that it returns a generic error message like `'Invalid token'`.
- Optionally, log the actual exception (e.g., to stderr with `print`, or through your application's logging framework) for safe debugging, but never expose this detail to the client.

All changes are in `security_fixes.py` within the method `SecurityMiddleware.require_auth`.  
No new methods are strictly needed, but if logging is part of project practices, ensure to log the exception as appropriate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
