### PR TITLE
Potential fix for code scanning alert no. 90: Information exposure through an exception

### DIFF
--- a/secure_production_api_server.py
+++ b/secure_production_api_server.py
@@ -913,9 +913,10 @@ Type: {template.upper()}
                 }), 200
                 
             except ValueError as e:
+                logger.warning(f"Invalid client request: {str(e)}")
                 return jsonify({
                     'success': False,
-                    'error': str(e)
+                    'error': 'Invalid request'
                 }), 400
                 
             except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/90](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/90)

To fix this information exposure issue, return a generic and user-friendly error message rather than returning the raw exception string (`str(e)`). Log the details of the exception (including the message/stack trace) on the server side for troubleshooting by administrators/developers. 

- Specifically, in the `except ValueError as e:` block (~lines 915-919), remove `str(e)` from the JSON error output and instead insert a generic message such as "Invalid request". Ensure the exception message is logged locally using the logger.
- Make this change only for the `ValueError` handling; the catch-all exception handler below already uses a generic error.
- You may need to ensure the logger is available in this context.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
