### PR TITLE
Potential fix for code scanning alert no. 101: Information exposure through an exception

### DIFF
--- a/production_api_server_dev.py
+++ b/production_api_server_dev.py
@@ -347,7 +347,7 @@ class ProductionAPIServer:
                 logger.error(traceback.format_exc())
                 return jsonify({
                     'success': False,
-                    'error': f'Analysis failed: {str(e)}',
+                    'error': 'An internal error occurred during analysis.',
                     'correlation_id': g.correlation_id
                 }), 500
         


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/101](https://github.com/Org-EthereaLogic/DocDevAI-v3.0.0/security/code-scanning/101)

To fix the problem, we should change the API response in the `/api/analyze` endpoint's exception handler so that only a generic error message is returned to the user, while the actual exception details are retained in the server log (which is already being done). Specifically, lines 348–350 should be modified: instead of including `str(e)` in the `'error'` field of the JSON response, provide a generic message such as "An internal error occurred during analysis." This way, users do not receive internal server detail, but developers can still review the logs for troubleshooting.

Only the exception handler in the `/api/analyze` endpoint (`analyze_quality` function) needs to be modified as per the code shown (if others are similar, they would need separate review). No additional imports or definitions are required, as logging is already in place.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
